### PR TITLE
Add Option to Disable Autofocus

### DIFF
--- a/src/components/Chat.js
+++ b/src/components/Chat.js
@@ -35,7 +35,8 @@ class TextInput extends React.Component {
     onHeightChange: PropTypes.func,
     onKeyDown: PropTypes.func,
     placeholder: PropTypes.string,
-    value: PropTypes.string
+    value: PropTypes.string,
+    autofocus: PropTypes.bool
   }
 
   static defaultProps = {
@@ -58,7 +59,9 @@ class TextInput extends React.Component {
   }
 
   _focusTextComposer() {
-    this.textarea.focus();
+    if (this.props.autofocus !== false) {
+      this.textarea.focus();
+    }
   }
 
   componentDidUpdate() {
@@ -77,7 +80,7 @@ class TextInput extends React.Component {
     return (
       <TextComposer.Context.Consumer>
         {context =>
-          <StyledInput {...this._contextToInputContext(this.props, context)} inputRef={this._setTextareaRef} />
+          <StyledInput {...this._contextToInputContext(_.omit(this.props, ['autofocus']), context)} inputRef={this._setTextareaRef} />
         }
       </TextComposer.Context.Consumer>
     );
@@ -376,7 +379,7 @@ export default class Chat extends React.Component {
   }
 
   render() {
-    const { otherAuthor, onFocus, onBlur, theme } = this.props;
+    const { otherAuthor, onFocus, onBlur, theme, autofocus } = this.props;
     const { messages, typingIndicator, quickReplies } = this.state;
 
     const parsedMessages = messages.reduce((result, current) => {
@@ -399,7 +402,7 @@ export default class Chat extends React.Component {
             <div style={{ float:"left", clear: "both", height: '0px', width: '0px', padding: '0px', margin: '0px', visibility: 'hidden' }} ref={(el) => { this.messagesEnd = el; }} />
           </MessageList>
           <TextComposer onSend={this._onSend} onFocus={onFocus} onBlur={onBlur}>
-            <TextInput />
+            <TextInput autofocus={autofocus} />
           </TextComposer>
         </StyledChat>
       </ThemeProvider>


### PR DESCRIPTION
Added option to disable autofocus.

Use Case: If a user is on mobile, it might become annoying if the textbox keeps getting autofocused every time they click a quick action.