### PR TITLE
Replace scrollTo with scrollTop

### DIFF
--- a/src/components/Chat.js
+++ b/src/components/Chat.js
@@ -431,9 +431,7 @@ export default class Chat extends React.Component {
   }
 
   scrollToBottom = () => {
-    this.parentScroll.scrollTo({
-      top: this.messagesEnd.offsetTop
-    });
+    this.parentScroll.scrollTop = this.messagesEnd.offsetTop;
   }
 
   componentDidMount() {


### PR DESCRIPTION
Microsoft Edge does not support `scrollTo` so it needs to be replaced with `scrollTop`.